### PR TITLE
Fetch correct _module_id value in apache::mod::php

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -70,8 +70,8 @@ class apache::mod::php (
     $_lib = "${libphp_prefix}${php_version}.so"
   }
   $_module_id = $_php_major ? {
-    '5'     => 'php5_module',
-    '7'     => 'php7_module',
+    /^5/     => 'php5_module',
+    /^7/     => 'php7_module',
     default => 'php_module',
   }
 


### PR DESCRIPTION
[CentOS, can't speak for other distros] The _module_id works fine with PHP from standard repo's. However, the PHP version in those repositories is usually old, and sometimes you need a newer PHP version, in which case one often uses the Remi repository. If you want to use e.g. php74, it will be installed without issues, but Apache will not start:

```puppet
class { 'apache::mod::php':
  package_name => 'php74',
  php_version => '74',
}
```

```
Jul 01 10:29:07 server-1 httpd[15883]: httpd: Syntax error on line 40 of /etc/httpd/conf/httpd.conf: Syntax error on line 1 of /etc/httpd/conf.modules.d/php.load: Can't locate API module structure `php_module' in file /etc/httpd/modules/libphp74.so: /etc/httpd/modules/libphp74.so: undefined symbol: php_module
```

```shell
# cat /etc/httpd/conf.modules.d/php.load
LoadModule php_module modules/libphp74.so
```

I traced this to:

```puppet
$_module_id = $_php_major ? {
  '5'     => 'php5_module',
  '7'     => 'php7_module',
  default => 'php_module',
}
```

With the example above, `$_php_major` isn't matching `7` but `74`. Therefore `$_module_id` defaults to `php_module` instead of `php7_module` and Apache will not start.
When a regex is used to match `/^5/` and `/^7/`, `$_module_id` will be set to `php7_module`, configuring the `php.load` file properly and Apache will start:

```shell
# cat /etc/httpd/conf.modules.d/php.load
LoadModule php7_module modules/libphp74.so
```